### PR TITLE
Fix usage with CMake's FetchContent module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,14 +84,12 @@ target_link_libraries(cppgpio-static Threads::Threads)
 target_include_directories(cppgpio
 	PUBLIC
 	$<INSTALL_INTERFACE:include>
-	PRIVATE
 	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
 )
 
 target_include_directories(cppgpio-static
 	PUBLIC
 	$<INSTALL_INTERFACE:include>
-	PRIVATE
 	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
 )
 


### PR DESCRIPTION
this makes the BUILD_INTERFACE includes PUBLIC which allows access to the headers when the project was included using the FetchContent module (https://cmake.org/cmake/help/latest/module/FetchContent.html)